### PR TITLE
Android: initialize `basePathStore` when RSDK activity is launched directly

### DIFF
--- a/android/app/src/main/java/org/rems/rsdkv5/Launcher.java
+++ b/android/app/src/main/java/org/rems/rsdkv5/Launcher.java
@@ -33,7 +33,7 @@ public class Launcher extends AppCompatActivity {
 
     public static Launcher instance = null;
 
-    private static File basePathStore;
+    public static File basePathStore;
 
     private static ActivityResultLauncher<Intent> folderLauncher = null;
     private static ActivityResultLauncher<Intent> gameLauncher = null;

--- a/android/app/src/main/java/org/rems/rsdkv5/RSDK.java
+++ b/android/app/src/main/java/org/rems/rsdkv5/RSDK.java
@@ -2,6 +2,7 @@ package org.rems.rsdkv5;
 
 import static android.os.Build.VERSION.SDK_INT;
 
+import java.io.File;
 import java.io.FileDescriptor;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -84,8 +85,10 @@ public class RSDK extends GameActivity {
         if (basePath == null) {
             if (getIntent().getData() != null) {
                 basePath = getIntent().getData();
-            } else
+            } else {
+                Launcher.basePathStore = new File(getFilesDir(), "basePathStore"); 
                 basePath = Launcher.refreshStore();
+            }
 
             if (basePath == null) {
                 Log.e("RSDKv5-J", "Base path file not found; game cannot be started standalone.");


### PR DESCRIPTION
This allows frontends to launch the `RSDK` activity directly, avoiding the 5 second wait for switching paths at startup.