### PR TITLE
Fix compiler error for Steam configuration

### DIFF
--- a/RSDKv5/RSDK/User/Steam/SteamAchievements.hpp
+++ b/RSDKv5/RSDK/User/Steam/SteamAchievements.hpp
@@ -3,7 +3,7 @@
 struct SteamAchievements : UserAchievements {
     void TryUnlockAchievement(AchievementID *id)
     {
-        if (name) {
+        if (id) {
             // try unlock a steam achievement
         }
     }


### PR DESCRIPTION
At some point the name got moved to inside an AchievementID structure, so check that value instead.