### PR TITLE
Add v5 dev menu character select and GetChannelAttributes to ModAPI v3

### DIFF
--- a/RSDKv5/RSDK/Core/Legacy/v3/RetroEnginev3.cpp
+++ b/RSDKv5/RSDK/Core/Legacy/v3/RetroEnginev3.cpp
@@ -62,7 +62,8 @@ bool32 RSDK::Legacy::v3::LoadGameConfig(const char *filepath)
 
 #if RETRO_USE_MOD_LOADER
             // needed for PlayerName[] stuff in scripts
-            StrCopy(modSettings.playerNames[p], strBuffer);
+            StrCopy(modSettings.players[p].name, strBuffer);
+            modSettings.players[p].id = p;
             modSettings.playerCount++;
 #endif
         }
@@ -565,8 +566,10 @@ void RSDK::Legacy::v3::LoadXMLWindowText(const tinyxml2::XMLElement *gameElement
     const tinyxml2::XMLElement *titleElement = gameElement->FirstChildElement("title");
     if (titleElement) {
         const tinyxml2::XMLAttribute *nameAttr = titleElement->FindAttribute("name");
-        if (nameAttr)
-            StrCopy(gameVerInfo.gameTitle, nameAttr->Value());
+        if (nameAttr) {
+            // Keep enough space for appending '\0'
+            strncpy(gameVerInfo.gameTitle, nameAttr->Value(), sizeof(gameVerInfo.gameTitle) - 1);
+        }
     }
 }
 
@@ -736,7 +739,7 @@ void RSDK::Legacy::v3::LoadXMLPlayers(const tinyxml2::XMLElement *gameElement)
             if (nameAttr)
                 plrName = nameAttr->Value();
 
-            StrCopy(modSettings.playerNames[modSettings.playerCount++], plrName);
+            AddDevMenuCharacter(plrName, modSettings.playerCount);
         }
     }
 }

--- a/RSDKv5/RSDK/Core/Legacy/v4/RetroEnginev4.cpp
+++ b/RSDKv5/RSDK/Core/Legacy/v4/RetroEnginev4.cpp
@@ -66,7 +66,8 @@ bool32 RSDK::Legacy::v4::LoadGameConfig(const char *filepath)
 
 #if RETRO_USE_MOD_LOADER
             // needed for PlayerName[] stuff in scripts
-            StrCopy(modSettings.playerNames[p], strBuffer);
+            StrCopy(modSettings.players[p].name, strBuffer);
+            modSettings.players[p].id = p;
             modSettings.playerCount++;
 #endif
         }
@@ -358,8 +359,10 @@ void RSDK::Legacy::v4::LoadXMLWindowText(const tinyxml2::XMLElement *gameElement
     const tinyxml2::XMLElement *titleElement = gameElement->FirstChildElement("title");
     if (titleElement) {
         const tinyxml2::XMLAttribute *nameAttr = titleElement->FindAttribute("name");
-        if (nameAttr)
-            StrCopy(gameVerInfo.gameTitle, nameAttr->Value());
+        if (nameAttr) {
+            // Keep enough space for appending '\0'
+            strncpy(gameVerInfo.gameTitle, nameAttr->Value(), sizeof(gameVerInfo.gameTitle) - 1);
+        }
     }
 }
 
@@ -534,7 +537,7 @@ void RSDK::Legacy::v4::LoadXMLPlayers(const tinyxml2::XMLElement *gameElement)
             if (nameAttr)
                 plrName = nameAttr->Value();
 
-            StrCopy(modSettings.playerNames[modSettings.playerCount++], plrName);
+            AddDevMenuCharacter(plrName, modSettings.playerCount);
         }
     }
 }

--- a/RSDKv5/RSDK/Core/ModAPI.cpp
+++ b/RSDKv5/RSDK/Core/ModAPI.cpp
@@ -234,6 +234,13 @@ void RSDK::InitModAPI(bool32 getVersion)
 
     // Graphics
     ADD_MOD_FUNCTION(ModTable_LoadPaletteLegacy, LoadPaletteLegacy);
+
+    // Audio
+    ADD_MOD_FUNCTION(ModTable_GetChannelAttributes, GetChannelAttributes);
+
+    // Dev Menu Characters
+    ADD_MOD_FUNCTION(ModTable_AddDevMenuCharacter, AddDevMenuCharacter);
+    ADD_MOD_FUNCTION(ModTable_GetActiveDevMenuCharacter, GetActiveDevMenuCharacter);
 #endif
 
     superLevels.clear();
@@ -512,11 +519,13 @@ void RSDK::UnloadMods()
     memset(Legacy::modScriptFlags, 0, sizeof(Legacy::modScriptFlags));
     Legacy::modObjCount = 0;
 
-    memset(modSettings.playerNames, 0, sizeof(modSettings.playerNames));
-    modSettings.playerCount = 0;
-
     modSettings.versionOverride = 0;
     modSettings.activeMod       = -1;
+#endif
+
+#if RETRO_REV0U || RETRO_MOD_LOADER_VER >= 3
+    memset(modSettings.players, 0, sizeof(modSettings.players));
+    modSettings.playerCount = 0;
 #endif
 
     customUserFileDir[0] = 0;
@@ -2261,6 +2270,34 @@ void RSDK::LoadPaletteLegacy(uint8 bankID, const char *filename, int32 startDstI
 
         CloseFile(&info);
     }
+}
+
+// Audio
+
+void RSDK::GetChannelAttributes(uint8 channel, float *volume, float *panning, float *speed)
+{
+    if (channel < CHANNEL_COUNT) {
+        if (volume)
+            *volume = channels[channel].volume;
+        if (panning)
+            *panning = channels[channel].pan;
+        if (speed)
+            *speed = (float)(channels[channel].speed) / TO_FIXED(1);
+    }
+}
+
+// Dev Menu Characters
+
+void RSDK::AddDevMenuCharacter(const char *playerName, int32 id)
+{
+    if (modSettings.playerCount >= PLAYERNAME_COUNT) {
+        PrintLog(PRINT_ERROR, "[MOD] ERROR: Failed to add dev menu character '%s' (max limit reached)", playerName);
+        return;
+    }
+
+    StrCopy(modSettings.players[modSettings.playerCount].name, playerName);
+    modSettings.players[modSettings.playerCount].id = id;
+    modSettings.playerCount++;
 }
 
 #endif /* RETRO_MOD_LOADER_VER >= 3 */

--- a/RSDKv5/RSDK/Core/ModAPI.hpp
+++ b/RSDKv5/RSDK/Core/ModAPI.hpp
@@ -19,7 +19,7 @@ namespace RSDK
 
 #if RETRO_USE_MOD_LOADER
 
-#define LEGACY_PLAYERNAME_COUNT (0x10)
+#define PLAYERNAME_COUNT (0x10)
 
 extern std::map<uint32, uint32> superLevels;
 extern int32 inheritLevel;
@@ -166,6 +166,13 @@ enum ModFunctionTableIDs {
 
     // Graphics
     ModTable_LoadPaletteLegacy,
+
+    // Audio
+    ModTable_GetChannelAttributes,
+
+    // Dev Menu Characters
+    ModTable_AddDevMenuCharacter,
+    ModTable_GetActiveDevMenuCharacter,
 #endif
 
     ModTable_Count
@@ -233,6 +240,13 @@ struct StateHook {
     bool32 priority;
 };
 
+#if RETRO_REV0U || RETRO_MOD_LOADER_VER >= 3
+struct PlayerInfo {
+    char name[0x20];
+    int32 id;
+};
+#endif
+
 struct ModSettings {
     int32 activeMod         = -1;
     bool32 redirectSaveRAM  = false;
@@ -241,8 +255,10 @@ struct ModSettings {
 #if RETRO_REV0U
     int32 versionOverride = 0;
     bool32 forceScripts   = false;
+#endif
 
-    char playerNames[LEGACY_PLAYERNAME_COUNT][0x20];
+#if RETRO_REV0U || RETRO_MOD_LOADER_VER >= 3
+    PlayerInfo players[PLAYERNAME_COUNT];
     int32 playerCount = 0;
 #endif
 };
@@ -485,6 +501,18 @@ void SetGameTitle(const char *name);
 
 // Graphics
 void LoadPaletteLegacy(uint8 bankID, const char *filename, int32 startDstIndex, int32 startSrcIndex, int32 endSrcIndex);
+
+// Audio
+void GetChannelAttributes(uint8 channel, float *volume, float *panning, float *speed);
+
+// Dev Menu Characters
+void AddDevMenuCharacter(const char *playerName, int32 id);
+inline int32 GetActiveDevMenuCharacter(void)
+{
+    if (!modSettings.playerCount)
+        return -1;
+    return playerListPos;
+}
 #endif
 
 #endif

--- a/RSDKv5/RSDK/Core/RetroEngine.hpp
+++ b/RSDKv5/RSDK/Core/RetroEngine.hpp
@@ -675,7 +675,10 @@ void LoadXMLWindowText(const tinyxml2::XMLElement *gameElement);
 void LoadXMLPalettes(const tinyxml2::XMLElement *gameElement);
 void LoadXMLObjects(const tinyxml2::XMLElement* gameElement);
 void LoadXMLSoundFX(const tinyxml2::XMLElement* gameElement);
-void LoadXMLStages(const tinyxml2::XMLElement* gameElement);
+#if RETRO_MOD_LOADER_VER >= 3
+void LoadXMLPlayers(const tinyxml2::XMLElement *gameElement);
+#endif
+void LoadXMLStages(const tinyxml2::XMLElement *gameElement);
 #endif
 
 void LoadGameConfig();

--- a/RSDKv5/RSDK/Dev/Debug.cpp
+++ b/RSDKv5/RSDK/Dev/Debug.cpp
@@ -349,6 +349,8 @@ void RSDK::DevMenu_MainMenu()
     else
         DrawDevString(RETRO_DEV_EXTRA, currentScreen->center.x, y, ALIGN_CENTER, 0x808090);
 #endif
+#elif defined(RETRO_DEV_EXTRA)
+    DrawDevString(RETRO_DEV_EXTRA, currentScreen->center.x, y, ALIGN_CENTER, 0x808090);
 #endif
     y += 8;
     DrawDevString(gameVerInfo.gameTitle, currentScreen->center.x, y, ALIGN_CENTER, 0x808090);
@@ -473,7 +475,11 @@ void RSDK::DevMenu_MainMenu()
 #if RETRO_REV0U
                 switch (engine.version) {
                     default: break;
-                    case 5: sceneInfo.state = ENGINESTATE_LOAD; break;
+                    case 5:
+#if RETRO_USE_MOD_LOADER && RETRO_MOD_LOADER_VER >= 3
+                        RSDK::playerListPos = -1;
+#endif
+                        sceneInfo.state = ENGINESTATE_LOAD; break;
 
                     case 4:
                     case 3:
@@ -487,8 +493,9 @@ void RSDK::DevMenu_MainMenu()
                 break;
 
             case 2:
-#if RETRO_REV0U && RETRO_USE_MOD_LOADER
-                if (engine.version == 5) {
+#if RETRO_USE_MOD_LOADER && (RETRO_REV0U || RETRO_MOD_LOADER_VER >= 3)
+                devMenu.playerListPos = confirm ? 0 : -1;
+                if (!modSettings.playerCount || devMenu.playerListPos == -1) {
                     devMenu.state     = DevMenu_CategorySelectMenu;
                     devMenu.selection = 0;
                     devMenu.timer     = 1;
@@ -668,8 +675,8 @@ void RSDK::DevMenu_CategorySelectMenu()
     }
 #if !RETRO_USE_ORIGINAL_CODE
     else if (swap ? controller[CONT_ANY].keyA.press : controller[CONT_ANY].keyB.press) {
-#if RETRO_REV0U && RETRO_USE_MOD_LOADER
-        if (engine.version == 5) {
+#if RETRO_USE_MOD_LOADER && ( RETRO_REV0U || RETRO_MOD_LOADER_VER >= 3)
+        if (!modSettings.playerCount || devMenu.playerListPos == -1) {
             devMenu.state     = DevMenu_MainMenu;
             devMenu.listPos   = 0;
             devMenu.scrollPos = 0;
@@ -803,16 +810,25 @@ void RSDK::DevMenu_SceneSelectMenu()
 #if RETRO_REV0U
             switch (engine.version) {
                 default: break;
-                case 5: sceneInfo.state = ENGINESTATE_LOAD; break;
+                case 5:
+#if RETRO_USE_MOD_LOADER && RETRO_MOD_LOADER_VER >= 3
+                    if (devMenu.playerListPos > -1)
+                        RSDK::playerListPos = modSettings.players[devMenu.playerListPos].id;
+                    else
+                        RSDK::playerListPos = -1;
+#endif
+                    sceneInfo.state = ENGINESTATE_LOAD; break;
                 case 4:
                 case 3:
 #if !RETRO_USE_ORIGINAL_CODE
                     RSDK::Legacy::debugMode = confirm;
 #endif
 #if RETRO_USE_MOD_LOADER
-                    switch (engine.version) {
-                        case 3: RSDK::Legacy::v3::playerListPos = devMenu.playerListPos; break;
-                        case 4: RSDK::Legacy::v4::playerListPos = devMenu.playerListPos; break;
+                    if (devMenu.playerListPos > -1) {
+                        switch (engine.version) {
+                            case 3: RSDK::Legacy::v3::playerListPos = modSettings.players[devMenu.playerListPos].id; break;
+                            case 4: RSDK::Legacy::v4::playerListPos = modSettings.players[devMenu.playerListPos].id; break;
+                        }
                     }
 #endif
                     RSDK::Legacy::gameMode  = RSDK::Legacy::ENGINE_MAINGAME;
@@ -820,12 +836,18 @@ void RSDK::DevMenu_SceneSelectMenu()
                     break;
             }
 #else
+#if RETRO_USE_MOD_LOADER && RETRO_MOD_LOADER_VER >= 3
+            if (devMenu.playerListPos > -1)
+                RSDK::playerListPos = modSettings.players[devMenu.playerListPos].id;
+            else
+                RSDK::playerListPos = -1;
+#endif
             sceneInfo.state = ENGINESTATE_LOAD;
 #endif //! RETRO_REV0U
 
-                // Bug Details(?):
-                // rev01 had this here, rev02 does not.
-                // This can cause an annoying popup when starting a stage
+            // Bug Details(?):
+            // rev01 had this here, rev02 does not.
+            // This can cause an annoying popup when starting a stage
 #if !RETRO_REV02
             AssignInputSlotToDevice(CONT_P1, INPUT_AUTOASSIGN);
 #endif
@@ -1955,7 +1977,7 @@ void RSDK::DevMenu_ModsMenu()
 }
 #endif
 
-#if RETRO_REV0U && RETRO_USE_MOD_LOADER
+#if RETRO_USE_MOD_LOADER && (RETRO_REV0U || RETRO_MOD_LOADER_VER >= 3)
 void RSDK::DevMenu_PlayerSelectMenu()
 {
     uint32 selectionColors[] = {
@@ -1973,7 +1995,7 @@ void RSDK::DevMenu_PlayerSelectMenu()
     int32 y = dy + 40;
     for (int32 i = 0; i < 8; ++i) {
         if (devMenu.scrollPos + i < modSettings.playerCount) {
-            DrawDevString(modSettings.playerNames[devMenu.scrollPos + i], currentScreen->center.x - 64, y, ALIGN_LEFT, selectionColors[i]);
+            DrawDevString(modSettings.players[devMenu.scrollPos + i].name, currentScreen->center.x - 64, y, ALIGN_LEFT, selectionColors[i]);
             y += 8;
         }
     }
@@ -2050,6 +2072,7 @@ void RSDK::DevMenu_PlayerSelectMenu()
     if (controller[CONT_ANY].keyStart.press || confirm) {
         devMenu.state         = DevMenu_CategorySelectMenu;
         devMenu.playerListPos = devMenu.selection;
+        devMenu.scrollPos     = 0;
         devMenu.selection     = 0;
         devMenu.timer         = 1;
     }

--- a/RSDKv5/RSDK/Dev/Debug.hpp
+++ b/RSDKv5/RSDK/Dev/Debug.hpp
@@ -115,7 +115,7 @@ struct DevMenu {
 #if RETRO_USE_MOD_LOADER
     bool32 modsChanged;
     uint8 startingVersion;
-#if RETRO_REV0U
+#if RETRO_REV0U || RETRO_MOD_LOADER_VER >= 3
     int32 playerListPos;
 #endif
 #endif

--- a/RSDKv5/RSDK/Scene/Legacy/v3/ScriptLegacyv3.cpp
+++ b/RSDKv5/RSDK/Scene/Legacy/v3/ScriptLegacyv3.cpp
@@ -1240,9 +1240,9 @@ void RSDK::Legacy::v3::ConvertFunctionText(char *text)
                 funcName[1] = 0;
 
                 int32 p = 0;
-                for (; p < LEGACY_PLAYERNAME_COUNT; ++p) {
+                for (; p < PLAYERNAME_COUNT; ++p) {
                     char buf[0x40];
-                    char *str = modSettings.playerNames[p];
+                    char *str = modSettings.players[p].name;
                     int32 pos = 0;
 
                     while (*str) {
@@ -1259,7 +1259,7 @@ void RSDK::Legacy::v3::ConvertFunctionText(char *text)
                     }
                 }
 
-                if (p == LEGACY_PLAYERNAME_COUNT)
+                if (p == PLAYERNAME_COUNT)
                     PrintLog(PRINT_NORMAL, "WARNING: Unknown PlayerName \"%s\", on line %d", arrayStr, lineID);
             }
 

--- a/RSDKv5/RSDK/Scene/Legacy/v4/ScriptLegacyv4.cpp
+++ b/RSDKv5/RSDK/Scene/Legacy/v4/ScriptLegacyv4.cpp
@@ -1806,9 +1806,9 @@ void RSDK::Legacy::v4::ConvertFunctionText(char *text)
                 funcName[1] = 0;
 
                 int32 p = 0;
-                for (; p < LEGACY_PLAYERNAME_COUNT; ++p) {
+                for (; p < PLAYERNAME_COUNT; ++p) {
                     char buf[0x40];
-                    char *str = modSettings.playerNames[p];
+                    char *str = modSettings.players[p].name;
                     int32 pos = 0;
 
                     while (*str) {
@@ -1825,7 +1825,7 @@ void RSDK::Legacy::v4::ConvertFunctionText(char *text)
                     }
                 }
 
-                if (p == LEGACY_PLAYERNAME_COUNT)
+                if (p == PLAYERNAME_COUNT)
                     PrintLog(PRINT_NORMAL, "WARNING: Unknown PlayerName \"%s\", on line %d", arrayStr, lineID);
             }
 
@@ -2140,9 +2140,9 @@ void RSDK::Legacy::v4::CheckCaseNumber(char *text)
             caseValue[1] = 0;
 
             int32 p = 0;
-            for (; p < LEGACY_PLAYERNAME_COUNT; ++p) {
+            for (; p < PLAYERNAME_COUNT; ++p) {
                 char buf[0x40];
-                char *str = modSettings.playerNames[p];
+                char *str = modSettings.players[p].name;
                 int32 pos = 0;
 
                 while (*str) {
@@ -2159,7 +2159,7 @@ void RSDK::Legacy::v4::CheckCaseNumber(char *text)
                 }
             }
 
-            if (p == LEGACY_PLAYERNAME_COUNT)
+            if (p == PLAYERNAME_COUNT)
                 PrintLog(PRINT_NORMAL, "WARNING: Unknown PlayerName \"%s\", on line %d", arrayStr, lineID);
         }
 
@@ -2377,9 +2377,9 @@ bool32 RSDK::Legacy::v4::ReadSwitchCase(char *text)
                 caseValue[1] = 0;
 
                 int32 p = 0;
-                for (; p < LEGACY_PLAYERNAME_COUNT; ++p) {
+                for (; p < PLAYERNAME_COUNT; ++p) {
                     char buf[0x40];
-                    char *str = modSettings.playerNames[p];
+                    char *str = modSettings.players[p].name;
                     int32 pos = 0;
 
                     while (*str) {
@@ -2396,7 +2396,7 @@ bool32 RSDK::Legacy::v4::ReadSwitchCase(char *text)
                     }
                 }
 
-                if (p == LEGACY_PLAYERNAME_COUNT)
+                if (p == PLAYERNAME_COUNT)
                     PrintLog(PRINT_NORMAL, "WARNING: Unknown PlayerName \"%s\", on line %d", arrayStr, lineID);
             }
 

--- a/RSDKv5/RSDK/Scene/Scene.cpp
+++ b/RSDKv5/RSDK/Scene/Scene.cpp
@@ -21,6 +21,10 @@ char RSDK::currentSceneID[0x10];
 
 SceneInfo RSDK::sceneInfo;
 
+#if RETRO_USE_MOD_LOADER && RETRO_MOD_LOADER_VER >= 3
+int32 RSDK::playerListPos = -1;
+#endif
+
 void RSDK::LoadSceneFolder()
 {
 #if RETRO_PLATFORM == RETRO_ANDROID

--- a/RSDKv5/RSDK/Scene/Scene.hpp
+++ b/RSDKv5/RSDK/Scene/Scene.hpp
@@ -163,6 +163,10 @@ extern uint8 currentSceneFilter;
 
 extern SceneInfo sceneInfo;
 
+#if RETRO_USE_MOD_LOADER && RETRO_MOD_LOADER_VER >= 3
+extern int32 playerListPos;
+#endif
+
 extern uint8 tilesetPixels[TILESET_SIZE * 4];
 
 void LoadSceneFolder();
@@ -177,6 +181,9 @@ void ProcessSceneTimer();
 void SetScene(const char *categoryName, const char *sceneName);
 inline void LoadScene()
 {
+#if RETRO_USE_MOD_LOADER && RETRO_MOD_LOADER_VER >= 3
+    RSDK::playerListPos = -1;
+#endif
     if ((sceneInfo.state & ENGINESTATE_STEPOVER) == ENGINESTATE_STEPOVER)
         sceneInfo.state = ENGINESTATE_LOAD | ENGINESTATE_STEPOVER;
     else


### PR DESCRIPTION
Adds a custom character select for v5's dev menu in ModAPI v3, based on the one for the legacy modes and a proof of concept by Jd. Characters can be added via `AddDevMenuCharacter` or game.xml, and the active dev menu character can be retrieved via `GetActiveDevMenuCharacter`. In addition, pressing Start while highlighting Stage Select in the Dev Menu will skip the player select and let you keep your current character instead, in case you need a specific character combo.

playerListPos is `-1` whenever a dev menu character is not active. Active dev menu characters are only kept until the next scene load, in which case it'll be set to `-1`.

Also added `GetChannelAttributes`, which gets the volume, panning, and speed of a channel.

<img width="850" height="512" alt="image" src="https://github.com/user-attachments/assets/1223ada9-7046-45f0-995f-4e6cea15c387" />

Other changes:
- Added sanity checks to replacing the game title via game.xml, and fixed the data folder text not being applied when doing so in v5
- Fixed `RETRO_DEV_EXTRA` not showing in the dev menu without the mod loader