### PR TITLE
Fix some shoddy Vulkan code

### DIFF
--- a/RSDKv5/RSDK/Graphics/GLFW/GLFWRenderDevice.cpp
+++ b/RSDKv5/RSDK/Graphics/GLFW/GLFWRenderDevice.cpp
@@ -119,8 +119,7 @@ bool RenderDevice::Init()
     glfwWindowHint(GLFW_VISIBLE, GLFW_FALSE);
     glfwWindowHint(GLFW_SCALE_TO_MONITOR, GLFW_TRUE); // HiDPI scaling support
 #if GLFW_VERSION_MAJOR >= 3 && GLFW_VERSION_MINOR >= 4
-    // Disable framebuffer scaling which (surprisingly) makes the framebuffer scale correctly on Wayland
-    glfwWindowHint(GLFW_SCALE_FRAMEBUFFER, GLFW_FALSE);
+    glfwWindowHint(GLFW_SCALE_FRAMEBUFFER, GLFW_TRUE);
 #endif
 
     if ((window = CreateGLFWWindow()) == NULL)
@@ -299,7 +298,11 @@ bool RenderDevice::InitGraphicsAPI()
     Vector2 viewportPos{};
     Vector2 lastViewSize;
 
-    glfwGetWindowSize(window, &lastViewSize.x, &lastViewSize.y);
+    if (videoSettings.windowed)
+        glfwGetWindowSize(window, &lastViewSize.x, &lastViewSize.y);
+    else
+        glfwGetFramebufferSize(window, &lastViewSize.x, &lastViewSize.y);
+
     Vector2 viewportSize = lastViewSize;
 
     if ((viewSize.x / viewSize.y) <= ((pixelSize.x / pixelSize.y) + 0.1)) {

--- a/RSDKv5/RSDK/Graphics/Vulkan/VulkanRenderDevice.cpp
+++ b/RSDKv5/RSDK/Graphics/Vulkan/VulkanRenderDevice.cpp
@@ -274,8 +274,8 @@ bool RenderDevice::SetupRendering()
     appInfo.pApplicationName = "RSDK" ENGINE_V_NAME;
     appInfo.pEngineName      = "RSDK" ENGINE_V_NAME;
     // i aint trying to populate these vers
-    appInfo.applicationVersion = VK_MAKE_API_VERSION(0, 1, 0, 0);
-    appInfo.engineVersion      = VK_MAKE_API_VERSION(0, 1, 0, 0);
+    appInfo.applicationVersion = VK_MAKE_API_VERSION(0, 1, 2, 0);
+    appInfo.engineVersion      = VK_MAKE_API_VERSION(0, 1, 2, 0);
     appInfo.apiVersion         = VK_API_VERSION_1_1;
 
     VkInstanceCreateInfo instanceInfo{};

--- a/RSDKv5/RSDK/Graphics/Vulkan/VulkanRenderDevice.cpp
+++ b/RSDKv5/RSDK/Graphics/Vulkan/VulkanRenderDevice.cpp
@@ -1632,6 +1632,8 @@ void RenderDevice::FlipScreen()
     presentInfo.pImageIndices = &imageIndex;
 
     vkQueuePresentKHR(presentQueue, &presentInfo);
+
+    imageIndex += 1;
 }
 
 void RenderDevice::ReleaseShaderPipelines()

--- a/RSDKv5/RSDK/Graphics/Vulkan/VulkanRenderDevice.cpp
+++ b/RSDKv5/RSDK/Graphics/Vulkan/VulkanRenderDevice.cpp
@@ -146,7 +146,7 @@ VkBuffer RenderDevice::vertexBuffer;
 VkDeviceMemory RenderDevice::vertexBufferMemory;
 
 VkCommandPool RenderDevice::commandPool;
-VkCommandBuffer RenderDevice::commandBuffer;
+std::vector<VkCommandBuffer> RenderDevice::commandBuffers;
 
 VkQueue RenderDevice::graphicsQueue;
 VkQueue RenderDevice::presentQueue;
@@ -156,9 +156,9 @@ uint32 RenderDevice::presentIndex;
 VkViewport RenderDevice::viewport;
 VkRect2D RenderDevice::scissors;
 
-VkSemaphore RenderDevice::imageAvailableSemaphore;
-VkSemaphore RenderDevice::renderFinishedSemaphore;
-VkFence RenderDevice::inFlightFence;
+std::vector<VkSemaphore> RenderDevice::waitSemaphore;
+std::vector<VkSemaphore> RenderDevice::signalSemaphore;
+std::vector<VkFence> RenderDevice::flightFence;
 
 int32 RenderDevice::monitorIndex;
 
@@ -612,11 +612,19 @@ bool RenderDevice::InitGraphicsAPI()
     pickedExtent.height =
         CLAMP(pickedExtent.height, currentSwapDetails.capabilities.minImageExtent.height, currentSwapDetails.capabilities.maxImageExtent.height);
 
+    uint32_t framesInFlight = videoSettings.tripleBuffered ? 2 : 1;
+
+    waitSemaphore.reserve(framesInFlight);
+    flightFence.reserve(framesInFlight);
+    commandBuffers.reserve(framesInFlight);
+
     //! CREATE SWAPCHAIN
     uint32_t imageCount = currentSwapDetails.capabilities.minImageCount + 1;
     if (currentSwapDetails.capabilities.maxImageCount > 0 && imageCount > currentSwapDetails.capabilities.maxImageCount) {
         imageCount = currentSwapDetails.capabilities.maxImageCount;
     }
+
+    signalSemaphore.reserve(imageCount);
 
     VkSwapchainCreateInfoKHR swapCreateInfo{};
     swapCreateInfo.sType            = VK_STRUCTURE_TYPE_SWAPCHAIN_CREATE_INFO_KHR;
@@ -847,12 +855,9 @@ bool RenderDevice::InitGraphicsAPI()
     cmdAllocInfo.sType              = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
     cmdAllocInfo.commandPool        = commandPool;
     cmdAllocInfo.level              = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
-    cmdAllocInfo.commandBufferCount = 1;
+    cmdAllocInfo.commandBufferCount = framesInFlight;
+    vkAllocateCommandBuffers(device, &cmdAllocInfo, commandBuffers.data());
 
-    if (vkAllocateCommandBuffers(device, &cmdAllocInfo, &commandBuffer) != VK_SUCCESS) {
-        PrintLog(PRINT_NORMAL, "[VK] Failed to create command buffer");
-        return false;
-    }
 
     //! CREATE SYNCHRONIZATION OBJECTS
     VkSemaphoreCreateInfo semaphoreInfo{};
@@ -862,11 +867,20 @@ bool RenderDevice::InitGraphicsAPI()
     fenceInfo.sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO;
     fenceInfo.flags = VK_FENCE_CREATE_SIGNALED_BIT;
 
-    if (vkCreateSemaphore(device, &semaphoreInfo, nullptr, &imageAvailableSemaphore) != VK_SUCCESS
-        || vkCreateSemaphore(device, &semaphoreInfo, nullptr, &renderFinishedSemaphore) != VK_SUCCESS
-        || vkCreateFence(device, &fenceInfo, nullptr, &inFlightFence) != VK_SUCCESS) {
-        PrintLog(PRINT_NORMAL, "[VK] Unable to create sephamores");
+    for (int32 i = 0; i < framesInFlight; i++) {
+        if (vkCreateSemaphore(device, &semaphoreInfo, nullptr, &waitSemaphore[i]) != VK_SUCCESS
+            || vkCreateFence(device, &fenceInfo, nullptr, &flightFence[i]) != VK_SUCCESS
+        ) {
+            PrintLog(PRINT_ERROR, "[VK] Unable to create fence");
+        }
     }
+
+    for (int32 i = 0; i < imageCount; i++) {
+        if (vkCreateSemaphore(device, &semaphoreInfo, nullptr, &signalSemaphore[i]) != VK_SUCCESS) {
+            PrintLog(PRINT_ERROR, "[VK] Unable to create semaphore");
+        }
+    }
+
 
     //! TEXTURE CREATION
     for (int32 i = 0; i < SCREEN_COUNT; ++i) {
@@ -1411,14 +1425,20 @@ bool RenderDevice::ProcessEvents()
 }
 
 VkWriteDescriptorSet descriptorWrites[SCREEN_COUNT][2];
+int32 frameIndex = 0;
 
 void RenderDevice::FlipScreen()
 {
-    vkWaitForFences(device, 1, &inFlightFence, VK_TRUE, UINT64_MAX);
+    VkFence inFlightFence = flightFence[frameIndex];
+
+    vkQueueWaitIdle(presentQueue);
     vkResetFences(device, 1, &inFlightFence);
 
     uint32_t imageIndex;
+    VkSemaphore imageAvailableSemaphore = waitSemaphore[frameIndex];
     VkResult result = vkAcquireNextImageKHR(device, swapChain, UINT64_MAX, imageAvailableSemaphore, VK_NULL_HANDLE, &imageIndex);
+
+    VkSemaphore renderFinishedSemaphore = signalSemaphore[imageIndex];
 
     if (result == VK_ERROR_OUT_OF_DATE_KHR) {
         // RefreshWindow();
@@ -1466,7 +1486,7 @@ void RenderDevice::FlipScreen()
 #endif
     }
 
-    vkResetCommandBuffer(commandBuffer, 0);
+    VkCommandBuffer commandBuffer = commandBuffers[frameIndex];
 
     VkCommandBufferBeginInfo beginInfo{};
     beginInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
@@ -1593,18 +1613,14 @@ void RenderDevice::FlipScreen()
     VkSubmitInfo submitInfo{};
     submitInfo.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
 
-    VkSemaphore waitSemaphores[]      = { imageAvailableSemaphore };
     VkPipelineStageFlags waitStages[] = { VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT };
     submitInfo.waitSemaphoreCount     = 1;
-    submitInfo.pWaitSemaphores        = waitSemaphores;
+    submitInfo.pWaitSemaphores        = &imageAvailableSemaphore;
     submitInfo.pWaitDstStageMask      = waitStages;
-
-    submitInfo.commandBufferCount = 1;
-    submitInfo.pCommandBuffers    = &commandBuffer;
-
-    VkSemaphore signalSemaphores[]  = { renderFinishedSemaphore };
-    submitInfo.signalSemaphoreCount = 1;
-    submitInfo.pSignalSemaphores    = signalSemaphores;
+    submitInfo.commandBufferCount     = 1;
+    submitInfo.pCommandBuffers        = &commandBuffer;
+    submitInfo.signalSemaphoreCount   = 1;
+    submitInfo.pSignalSemaphores      = &renderFinishedSemaphore;
 
     if (vkQueueSubmit(graphicsQueue, 1, &submitInfo, inFlightFence) != VK_SUCCESS) {
         PrintLog(PRINT_NORMAL, "[VK] Failed to submit to graphics queue");
@@ -1613,17 +1629,15 @@ void RenderDevice::FlipScreen()
 
     VkPresentInfoKHR presentInfo{};
     presentInfo.sType = VK_STRUCTURE_TYPE_PRESENT_INFO_KHR;
-
     presentInfo.waitSemaphoreCount = 1;
-    presentInfo.pWaitSemaphores    = signalSemaphores;
-
-    VkSwapchainKHR swapChains[] = { swapChain };
-    presentInfo.swapchainCount  = 1;
-    presentInfo.pSwapchains     = swapChains;
-
+    presentInfo.pWaitSemaphores    = &renderFinishedSemaphore;
+    presentInfo.swapchainCount = 1;
+    presentInfo.pSwapchains     = &swapChain;
     presentInfo.pImageIndices = &imageIndex;
 
     vkQueuePresentKHR(presentQueue, &presentInfo);
+
+    frameIndex = (frameIndex + 1) % waitSemaphore.capacity();
 }
 
 void RenderDevice::ReleaseShaderPipelines()
@@ -1685,9 +1699,14 @@ void RenderDevice::Release(bool32 isRefresh)
     vkDestroyBuffer(device, vertexBuffer, nullptr);
     vkFreeMemory(device, vertexBufferMemory, nullptr);
 
-    vkDestroySemaphore(device, imageAvailableSemaphore, nullptr);
-    vkDestroySemaphore(device, renderFinishedSemaphore, nullptr);
-    vkDestroyFence(device, inFlightFence, nullptr);
+    for (int32 i = 0; i < waitSemaphore.capacity(); i++) {
+        vkDestroySemaphore(device, waitSemaphore[i], nullptr);
+        vkDestroyFence(device, flightFence[i], nullptr);
+    }
+
+    for (int32 i = 0; i < signalSemaphore.capacity(); i++) {
+        vkDestroySemaphore(device, signalSemaphore[i], nullptr);
+}
 
     vkDestroyCommandPool(device, commandPool, nullptr);
 

--- a/RSDKv5/RSDK/Graphics/Vulkan/VulkanRenderDevice.cpp
+++ b/RSDKv5/RSDK/Graphics/Vulkan/VulkanRenderDevice.cpp
@@ -214,6 +214,7 @@ GLFWwindow *RenderDevice::CreateGLFWWindow(void)
         PrintLog(PRINT_NORMAL, "ERROR: [GLFW] window creation failed");
         return NULL;
     }
+    glfwShowWindow(win); // window has to be shown first for scaling to be determined properly
     if (videoSettings.windowed) {
         // Center the window
         monitor                 = glfwGetPrimaryMonitor();
@@ -222,12 +223,11 @@ GLFWwindow *RenderDevice::CreateGLFWWindow(void)
         glfwGetMonitorPos(monitor, &x, &y);
         // Get scaling for HiDPI screens
         float xscale, yscale;
-        glfwGetMonitorContentScale(monitor, &xscale, &yscale);
+        glfwGetWindowContentScale(win, &xscale, &yscale);
         int xpos = x + (mode->width - (int)((float)videoSettings.windowWidth * xscale)) / 2;
         int ypos = y + (mode->height - (int)((float)videoSettings.windowHeight * yscale)) / 2;
         glfwSetWindowPos(win, xpos, ypos);
     }
-    glfwShowWindow(win);
     PrintLog(PRINT_NORMAL, "w: %d h: %d windowed: %d", w, h, videoSettings.windowed);
 
     glfwSetKeyCallback(win, ProcessKeyEvent);
@@ -246,8 +246,7 @@ bool RenderDevice::Init()
     glfwWindowHint(GLFW_VISIBLE, GLFW_FALSE);
     glfwWindowHint(GLFW_SCALE_TO_MONITOR, GLFW_TRUE); // HiDPI scaling support
 #if GLFW_VERSION_MAJOR >= 3 && GLFW_VERSION_MINOR >= 4
-    // Disable framebuffer scaling which (surprisingly) makes the framebuffer scale correctly on Wayland
-    glfwWindowHint(GLFW_SCALE_FRAMEBUFFER, GLFW_FALSE);
+    glfwWindowHint(GLFW_SCALE_FRAMEBUFFER, GLFW_TRUE);
 #endif
 
     if ((window = CreateGLFWWindow()) == NULL)
@@ -556,6 +555,16 @@ bool RenderDevice::InitGraphicsAPI()
     Vector2 lastViewSize;
 
     glfwGetWindowSize(window, &lastViewSize.x, &lastViewSize.y);
+
+    int platform = glfwGetPlatform();
+    if ((platform == GLFW_PLATFORM_WAYLAND || platform == GLFW_PLATFORM_COCOA) && !videoSettings.windowed) {
+        float2 windowScale;
+        glfwGetWindowContentScale(window, &windowScale.x, &windowScale.y);
+
+        lastViewSize.x *= windowScale.x;
+        lastViewSize.y *= windowScale.y;
+    }
+
     Vector2 viewportSize = lastViewSize;
 
     if ((viewSize.x / viewSize.y) <= ((pixelSize.x / pixelSize.y) + 0.1)) {

--- a/RSDKv5/RSDK/Graphics/Vulkan/VulkanRenderDevice.cpp
+++ b/RSDKv5/RSDK/Graphics/Vulkan/VulkanRenderDevice.cpp
@@ -154,6 +154,7 @@ uint32 RenderDevice::graphicsIndex;
 uint32 RenderDevice::presentIndex;
 
 VkViewport RenderDevice::viewport;
+VkRect2D RenderDevice::scissors;
 
 VkSemaphore RenderDevice::imageAvailableSemaphore;
 VkSemaphore RenderDevice::renderFinishedSemaphore;
@@ -412,12 +413,13 @@ bool RenderDevice::SetupRendering()
 
     deviceInfo.pEnabledFeatures = &deviceFeatures;
 
-#ifndef VK_DEBUG
-    deviceInfo.enabledLayerCount = 0;
-#else
-    deviceInfo.enabledLayerCount   = sizeof(validationLayers) / sizeof(const char *);
-    deviceInfo.ppEnabledLayerNames = validationLayers;
-#endif
+    // not conformant to vulkan spec: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-devicelayers
+// #ifndef VK_DEBUG
+//     deviceInfo.enabledLayerCount = 0;
+// #else
+//     deviceInfo.enabledLayerCount   = sizeof(validationLayers) / sizeof(const char *);
+//     deviceInfo.ppEnabledLayerNames = validationLayers;
+// #endif
 
     deviceInfo.enabledExtensionCount   = sizeof(requiredExtensions) / sizeof(const char *);
     deviceInfo.ppEnabledExtensionNames = requiredExtensions;
@@ -568,7 +570,7 @@ bool RenderDevice::InitGraphicsAPI()
         if ((pixAspect - 0.1) > (viewSize.x / viewSize.y)) {
             viewSize.y     = (pixelSize.y / pixelSize.x) * viewSize.x;
             viewportPos.y  = (lastViewSize.y >> 1) - (viewSize.y * 0.5);
-            viewportSize.y = viewSize.y;
+            viewportSize.y = viewSize.y - viewportPos.y;
         }
     }
     else {
@@ -744,12 +746,15 @@ bool RenderDevice::InitGraphicsAPI()
     viewport.minDepth = 0.0f;
     viewport.maxDepth = 1.0f;
 
+    scissors.offset = { (int32)viewportPos.x, (int32)viewportPos.y };
+    scissors.extent = { (uint32)viewportSize.x, (uint32)viewportSize.y };
+
     viewportState               = {};
     viewportState.sType         = VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO;
     viewportState.viewportCount = 1;
     viewportState.pViewports    = &viewport;
     viewportState.scissorCount  = 1;
-    viewportState.pScissors     = (VkRect2D *)&viewport;
+    viewportState.pScissors     = &scissors;
 
     rasterizer                         = {};
     rasterizer.sType                   = VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO;

--- a/RSDKv5/RSDK/Graphics/Vulkan/VulkanRenderDevice.cpp
+++ b/RSDKv5/RSDK/Graphics/Vulkan/VulkanRenderDevice.cpp
@@ -413,13 +413,12 @@ bool RenderDevice::SetupRendering()
 
     deviceInfo.pEnabledFeatures = &deviceFeatures;
 
-    // not conformant to vulkan spec: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-devicelayers
-// #ifndef VK_DEBUG
-//     deviceInfo.enabledLayerCount = 0;
-// #else
-//     deviceInfo.enabledLayerCount   = sizeof(validationLayers) / sizeof(const char *);
-//     deviceInfo.ppEnabledLayerNames = validationLayers;
-// #endif
+    // #ifndef VK_DEBUG
+    deviceInfo.enabledLayerCount = 0;
+    // #else
+    //     deviceInfo.enabledLayerCount   = sizeof(validationLayers) / sizeof(const char *);
+    //     deviceInfo.ppEnabledLayerNames = validationLayers;
+    // #endif
 
     deviceInfo.enabledExtensionCount   = sizeof(requiredExtensions) / sizeof(const char *);
     deviceInfo.ppEnabledExtensionNames = requiredExtensions;

--- a/RSDKv5/RSDK/Graphics/Vulkan/VulkanRenderDevice.cpp
+++ b/RSDKv5/RSDK/Graphics/Vulkan/VulkanRenderDevice.cpp
@@ -856,8 +856,11 @@ bool RenderDevice::InitGraphicsAPI()
     cmdAllocInfo.commandPool        = commandPool;
     cmdAllocInfo.level              = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
     cmdAllocInfo.commandBufferCount = framesInFlight;
-    vkAllocateCommandBuffers(device, &cmdAllocInfo, commandBuffers.data());
 
+    if (vkAllocateCommandBuffers(device, &cmdAllocInfo, commandBuffers.data()) != VK_SUCCESS) {
+        PrintLog(PRINT_NORMAL, "[VK] Failed to create command buffer");
+        return false;
+    }
 
     //! CREATE SYNCHRONIZATION OBJECTS
     VkSemaphoreCreateInfo semaphoreInfo{};

--- a/RSDKv5/RSDK/Graphics/Vulkan/VulkanRenderDevice.cpp
+++ b/RSDKv5/RSDK/Graphics/Vulkan/VulkanRenderDevice.cpp
@@ -413,13 +413,6 @@ bool RenderDevice::SetupRendering()
 
     deviceInfo.pEnabledFeatures = &deviceFeatures;
 
-    // #ifndef VK_DEBUG
-    deviceInfo.enabledLayerCount = 0;
-    // #else
-    //     deviceInfo.enabledLayerCount   = sizeof(validationLayers) / sizeof(const char *);
-    //     deviceInfo.ppEnabledLayerNames = validationLayers;
-    // #endif
-
     deviceInfo.enabledExtensionCount   = sizeof(requiredExtensions) / sizeof(const char *);
     deviceInfo.ppEnabledExtensionNames = requiredExtensions;
 

--- a/RSDKv5/RSDK/Graphics/Vulkan/VulkanRenderDevice.cpp
+++ b/RSDKv5/RSDK/Graphics/Vulkan/VulkanRenderDevice.cpp
@@ -560,13 +560,11 @@ bool RenderDevice::InitGraphicsAPI()
 
     if ((viewSize.x / viewSize.y) <= ((pixelSize.x / pixelSize.y) + 0.1)) {
         if ((pixAspect - 0.1) > (viewSize.x / viewSize.y)) {
-            viewSize.y     = (pixelSize.y / pixelSize.x) * viewSize.x;
             viewportPos.y  = (lastViewSize.y >> 1) - (viewSize.y * 0.5);
-            viewportSize.y = viewSize.y - (2 * viewportPos.y);
+            viewportSize.y = viewSize.y;
         }
     }
     else {
-        viewSize.x     = pixAspect * viewSize.y;
         viewportPos.x  = (lastViewSize.x >> 1) - ((pixAspect * viewSize.y) * 0.5);
         viewportSize.x = (pixAspect * viewSize.y);
     }

--- a/RSDKv5/RSDK/Graphics/Vulkan/VulkanRenderDevice.cpp
+++ b/RSDKv5/RSDK/Graphics/Vulkan/VulkanRenderDevice.cpp
@@ -1,6 +1,6 @@
 #ifdef VK_INTELLISENSE
-#include "RetroEngine.hpp"
-#include "VulkanRenderDevice.hpp"
+#include <RSDK/Core/RetroEngine.hpp>
+using namespace RSDK;
 #endif
 
 #include <set>

--- a/RSDKv5/RSDK/Graphics/Vulkan/VulkanRenderDevice.cpp
+++ b/RSDKv5/RSDK/Graphics/Vulkan/VulkanRenderDevice.cpp
@@ -216,7 +216,7 @@ GLFWwindow *RenderDevice::CreateGLFWWindow(void)
     }
     if (videoSettings.windowed) {
         // Center the window
-        monitor = glfwGetPrimaryMonitor();
+        monitor                 = glfwGetPrimaryMonitor();
         const GLFWvidmode *mode = glfwGetVideoMode(monitor);
         int x, y;
         glfwGetMonitorPos(monitor, &x, &y);
@@ -338,8 +338,8 @@ bool RenderDevice::SetupRendering()
     callbackInfo.sType           = VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT;
     callbackInfo.messageSeverity = VK_DEBUG_UTILS_MESSAGE_SEVERITY_VERBOSE_BIT_EXT | VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT
                                    | VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT;
-    callbackInfo.messageType = VK_DEBUG_UTILS_MESSAGE_TYPE_GENERAL_BIT_EXT | VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT
-                               | VK_DEBUG_UTILS_MESSAGE_TYPE_PERFORMANCE_BIT_EXT;
+    callbackInfo.messageType     = VK_DEBUG_UTILS_MESSAGE_TYPE_GENERAL_BIT_EXT | VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT
+                                   | VK_DEBUG_UTILS_MESSAGE_TYPE_PERFORMANCE_BIT_EXT;
     callbackInfo.pfnUserCallback = DebugCallback;
     callbackInfo.pUserData       = nullptr;
 
@@ -870,8 +870,7 @@ bool RenderDevice::InitGraphicsAPI()
 
     for (int32 i = 0; i < framesInFlight; i++) {
         if (vkCreateSemaphore(device, &semaphoreInfo, nullptr, &waitSemaphore[i]) != VK_SUCCESS
-            || vkCreateFence(device, &fenceInfo, nullptr, &flightFence[i]) != VK_SUCCESS
-        ) {
+            || vkCreateFence(device, &fenceInfo, nullptr, &flightFence[i]) != VK_SUCCESS) {
             PrintLog(PRINT_ERROR, "[VK] Unable to create fence");
         }
     }
@@ -1436,14 +1435,15 @@ void RenderDevice::FlipScreen()
 
     uint32_t imageIndex;
     VkSemaphore imageAvailableSemaphore = waitSemaphore[frameIndex];
-    VkResult result = vkAcquireNextImageKHR(device, swapChain, UINT64_MAX, imageAvailableSemaphore, VK_NULL_HANDLE, &imageIndex);
+    VkResult result                     = vkAcquireNextImageKHR(device, swapChain, UINT64_MAX, imageAvailableSemaphore, VK_NULL_HANDLE, &imageIndex);
 
     VkSemaphore renderFinishedSemaphore = signalSemaphore[imageIndex];
 
     if (result == VK_ERROR_OUT_OF_DATE_KHR) {
         // RefreshWindow();
         return;
-    } else if (result != VK_SUCCESS && result != VK_SUBOPTIMAL_KHR) {
+    }
+    else if (result != VK_SUCCESS && result != VK_SUBOPTIMAL_KHR) {
         PrintLog(PRINT_NORMAL, "[VK] Failed to acquire swapchain image");
         return;
     }
@@ -1516,7 +1516,8 @@ void RenderDevice::FlipScreen()
         imageInfo.sampler = shaderList[videoSettings.shaderID].linear ? samplerLinear : samplerPoint;
     }
 
-    vkCmdBindPipeline(commandBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS, shaderList[videoSettings.shaderSupport ? videoSettings.shaderID : 0].shaderPipeline);
+    vkCmdBindPipeline(commandBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS,
+                      shaderList[videoSettings.shaderSupport ? videoSettings.shaderID : 0].shaderPipeline);
     vkCmdSetViewport(commandBuffer, 0, 1, &viewport);
 
     VkBuffer vertexBuffers[] = { vertexBuffer };
@@ -1628,12 +1629,12 @@ void RenderDevice::FlipScreen()
     }
 
     VkPresentInfoKHR presentInfo{};
-    presentInfo.sType = VK_STRUCTURE_TYPE_PRESENT_INFO_KHR;
+    presentInfo.sType              = VK_STRUCTURE_TYPE_PRESENT_INFO_KHR;
     presentInfo.waitSemaphoreCount = 1;
     presentInfo.pWaitSemaphores    = &renderFinishedSemaphore;
-    presentInfo.swapchainCount = 1;
-    presentInfo.pSwapchains     = &swapChain;
-    presentInfo.pImageIndices = &imageIndex;
+    presentInfo.swapchainCount     = 1;
+    presentInfo.pSwapchains        = &swapChain;
+    presentInfo.pImageIndices      = &imageIndex;
 
     vkQueuePresentKHR(presentQueue, &presentInfo);
 
@@ -1706,7 +1707,7 @@ void RenderDevice::Release(bool32 isRefresh)
 
     for (int32 i = 0; i < signalSemaphore.size(); i++) {
         vkDestroySemaphore(device, signalSemaphore[i], nullptr);
-}
+    }
 
     vkDestroyCommandPool(device, commandPool, nullptr);
 
@@ -1832,7 +1833,7 @@ bool RenderDevice::InitShaders()
     videoSettings.shaderSupport = true;
     int32 maxShaders            = 0;
 #if RETRO_USE_MOD_LOADER
-    shaderCount                 = 0;
+    shaderCount = 0;
 #endif
 
     LoadShader("None", false);
@@ -2240,8 +2241,8 @@ void RenderDevice::ProcessKeyEvent(GLFWwindow *, int32 key, int32 scancode, int3
                     if (engine.devMenu) {
                         sceneInfo.listPos--;
                         while (sceneInfo.listPos < sceneInfo.listCategory[sceneInfo.activeCategory].sceneOffsetStart
-                            || sceneInfo.listPos > sceneInfo.listCategory[sceneInfo.activeCategory].sceneOffsetEnd
-                            || !sceneInfo.listCategory[sceneInfo.activeCategory].sceneCount) {
+                               || sceneInfo.listPos > sceneInfo.listCategory[sceneInfo.activeCategory].sceneOffsetEnd
+                               || !sceneInfo.listCategory[sceneInfo.activeCategory].sceneCount) {
                             sceneInfo.activeCategory--;
                             if (sceneInfo.activeCategory >= sceneInfo.categoryCount) {
                                 sceneInfo.activeCategory = sceneInfo.categoryCount - 1;
@@ -2266,8 +2267,8 @@ void RenderDevice::ProcessKeyEvent(GLFWwindow *, int32 key, int32 scancode, int3
                     if (engine.devMenu) {
                         sceneInfo.listPos++;
                         while (sceneInfo.listPos < sceneInfo.listCategory[sceneInfo.activeCategory].sceneOffsetStart
-                            || sceneInfo.listPos > sceneInfo.listCategory[sceneInfo.activeCategory].sceneOffsetEnd
-                            || !sceneInfo.listCategory[sceneInfo.activeCategory].sceneCount) {
+                               || sceneInfo.listPos > sceneInfo.listCategory[sceneInfo.activeCategory].sceneOffsetEnd
+                               || !sceneInfo.listCategory[sceneInfo.activeCategory].sceneCount) {
                             sceneInfo.activeCategory++;
                             if (sceneInfo.activeCategory >= sceneInfo.categoryCount) {
                                 sceneInfo.activeCategory = 0;

--- a/RSDKv5/RSDK/Graphics/Vulkan/VulkanRenderDevice.cpp
+++ b/RSDKv5/RSDK/Graphics/Vulkan/VulkanRenderDevice.cpp
@@ -569,7 +569,7 @@ bool RenderDevice::InitGraphicsAPI()
         if ((pixAspect - 0.1) > (viewSize.x / viewSize.y)) {
             viewSize.y     = (pixelSize.y / pixelSize.x) * viewSize.x;
             viewportPos.y  = (lastViewSize.y >> 1) - (viewSize.y * 0.5);
-            viewportSize.y = viewSize.y - viewportPos.y;
+            viewportSize.y = viewSize.y - (2 * viewportPos.y);
         }
     }
     else {

--- a/RSDKv5/RSDK/Graphics/Vulkan/VulkanRenderDevice.cpp
+++ b/RSDKv5/RSDK/Graphics/Vulkan/VulkanRenderDevice.cpp
@@ -1624,8 +1624,6 @@ void RenderDevice::FlipScreen()
     presentInfo.pImageIndices = &imageIndex;
 
     vkQueuePresentKHR(presentQueue, &presentInfo);
-
-    imageIndex += 1;
 }
 
 void RenderDevice::ReleaseShaderPipelines()

--- a/RSDKv5/RSDK/Graphics/Vulkan/VulkanRenderDevice.cpp
+++ b/RSDKv5/RSDK/Graphics/Vulkan/VulkanRenderDevice.cpp
@@ -1638,7 +1638,8 @@ void RenderDevice::FlipScreen()
 
     vkQueuePresentKHR(presentQueue, &presentInfo);
 
-    frameIndex = (frameIndex + 1) % waitSemaphore.capacity();
+    if (videoSettings.tripleBuffered)
+        frameIndex = (frameIndex + 1) % waitSemaphore.capacity();
 }
 
 void RenderDevice::ReleaseShaderPipelines()
@@ -2028,6 +2029,7 @@ void RenderDevice::RefreshWindow()
     QuerySwapChainDetails(physicalDevice);
 
     descriptorSet[0] = VK_NULL_HANDLE;
+    frameIndex = 0;
 
     if (!InitGraphicsAPI() || !InitShaders())
         return;

--- a/RSDKv5/RSDK/Graphics/Vulkan/VulkanRenderDevice.cpp
+++ b/RSDKv5/RSDK/Graphics/Vulkan/VulkanRenderDevice.cpp
@@ -884,7 +884,6 @@ bool RenderDevice::InitGraphicsAPI()
         }
     }
 
-
     //! TEXTURE CREATION
     for (int32 i = 0; i < SCREEN_COUNT; ++i) {
         VkImageCreateInfo imageInfo{};

--- a/RSDKv5/RSDK/Graphics/Vulkan/VulkanRenderDevice.cpp
+++ b/RSDKv5/RSDK/Graphics/Vulkan/VulkanRenderDevice.cpp
@@ -614,9 +614,9 @@ bool RenderDevice::InitGraphicsAPI()
 
     uint32_t framesInFlight = videoSettings.tripleBuffered ? 2 : 1;
 
-    waitSemaphore.reserve(framesInFlight);
-    flightFence.reserve(framesInFlight);
-    commandBuffers.reserve(framesInFlight);
+    waitSemaphore.resize(framesInFlight);
+    flightFence.resize(framesInFlight);
+    commandBuffers.resize(framesInFlight);
 
     //! CREATE SWAPCHAIN
     uint32_t imageCount = currentSwapDetails.capabilities.minImageCount + 1;
@@ -624,7 +624,7 @@ bool RenderDevice::InitGraphicsAPI()
         imageCount = currentSwapDetails.capabilities.maxImageCount;
     }
 
-    signalSemaphore.reserve(imageCount);
+    signalSemaphore.resize(imageCount);
 
     VkSwapchainCreateInfoKHR swapCreateInfo{};
     swapCreateInfo.sType            = VK_STRUCTURE_TYPE_SWAPCHAIN_CREATE_INFO_KHR;
@@ -1699,12 +1699,12 @@ void RenderDevice::Release(bool32 isRefresh)
     vkDestroyBuffer(device, vertexBuffer, nullptr);
     vkFreeMemory(device, vertexBufferMemory, nullptr);
 
-    for (int32 i = 0; i < waitSemaphore.capacity(); i++) {
+    for (int32 i = 0; i < waitSemaphore.size(); i++) {
         vkDestroySemaphore(device, waitSemaphore[i], nullptr);
         vkDestroyFence(device, flightFence[i], nullptr);
     }
 
-    for (int32 i = 0; i < signalSemaphore.capacity(); i++) {
+    for (int32 i = 0; i < signalSemaphore.size(); i++) {
         vkDestroySemaphore(device, signalSemaphore[i], nullptr);
 }
 

--- a/RSDKv5/RSDK/Graphics/Vulkan/VulkanRenderDevice.cpp
+++ b/RSDKv5/RSDK/Graphics/Vulkan/VulkanRenderDevice.cpp
@@ -214,7 +214,6 @@ GLFWwindow *RenderDevice::CreateGLFWWindow(void)
         PrintLog(PRINT_NORMAL, "ERROR: [GLFW] window creation failed");
         return NULL;
     }
-    glfwShowWindow(win); // window has to be shown first for scaling to be determined properly
     if (videoSettings.windowed) {
         // Center the window
         monitor                 = glfwGetPrimaryMonitor();
@@ -223,11 +222,12 @@ GLFWwindow *RenderDevice::CreateGLFWWindow(void)
         glfwGetMonitorPos(monitor, &x, &y);
         // Get scaling for HiDPI screens
         float xscale, yscale;
-        glfwGetWindowContentScale(win, &xscale, &yscale);
+        glfwGetMonitorContentScale(monitor, &xscale, &yscale);
         int xpos = x + (mode->width - (int)((float)videoSettings.windowWidth * xscale)) / 2;
         int ypos = y + (mode->height - (int)((float)videoSettings.windowHeight * yscale)) / 2;
         glfwSetWindowPos(win, xpos, ypos);
     }
+    glfwShowWindow(win);
     PrintLog(PRINT_NORMAL, "w: %d h: %d windowed: %d", w, h, videoSettings.windowed);
 
     glfwSetKeyCallback(win, ProcessKeyEvent);
@@ -554,26 +554,22 @@ bool RenderDevice::InitGraphicsAPI()
     Vector2 viewportPos{};
     Vector2 lastViewSize;
 
-    glfwGetWindowSize(window, &lastViewSize.x, &lastViewSize.y);
-
-    int platform = glfwGetPlatform();
-    if ((platform == GLFW_PLATFORM_WAYLAND || platform == GLFW_PLATFORM_COCOA) && !videoSettings.windowed) {
-        float2 windowScale;
-        glfwGetWindowContentScale(window, &windowScale.x, &windowScale.y);
-
-        lastViewSize.x *= windowScale.x;
-        lastViewSize.y *= windowScale.y;
-    }
+    if (videoSettings.windowed)
+        glfwGetWindowSize(window, &lastViewSize.x, &lastViewSize.y);
+    else
+        glfwGetFramebufferSize(window, &lastViewSize.x, &lastViewSize.y);
 
     Vector2 viewportSize = lastViewSize;
 
     if ((viewSize.x / viewSize.y) <= ((pixelSize.x / pixelSize.y) + 0.1)) {
         if ((pixAspect - 0.1) > (viewSize.x / viewSize.y)) {
+            viewSize.y     = (pixelSize.y / pixelSize.x) * viewSize.x;
             viewportPos.y  = (lastViewSize.y >> 1) - (viewSize.y * 0.5);
             viewportSize.y = viewSize.y;
         }
     }
     else {
+        viewSize.x     = pixAspect * viewSize.y;
         viewportPos.x  = (lastViewSize.x >> 1) - ((pixAspect * viewSize.y) * 0.5);
         viewportSize.x = (pixAspect * viewSize.y);
     }

--- a/RSDKv5/RSDK/Graphics/Vulkan/VulkanRenderDevice.hpp
+++ b/RSDKv5/RSDK/Graphics/Vulkan/VulkanRenderDevice.hpp
@@ -178,7 +178,7 @@ private:
     static VkDeviceMemory vertexBufferMemory;
 
     static VkCommandPool commandPool;
-    static VkCommandBuffer commandBuffer;
+    static std::vector<VkCommandBuffer> commandBuffers;
 
     static VkQueue graphicsQueue;
     static VkQueue presentQueue;
@@ -188,9 +188,9 @@ private:
     static VkViewport viewport;
     static VkRect2D scissors;
 
-    static VkSemaphore imageAvailableSemaphore;
-    static VkSemaphore renderFinishedSemaphore;
-    static VkFence inFlightFence;
+    static std::vector<VkSemaphore> waitSemaphore;
+    static std::vector<VkSemaphore> signalSemaphore;
+    static std::vector<VkFence> flightFence;
 
     static int32 monitorIndex;
 

--- a/RSDKv5/RSDK/Graphics/Vulkan/VulkanRenderDevice.hpp
+++ b/RSDKv5/RSDK/Graphics/Vulkan/VulkanRenderDevice.hpp
@@ -186,6 +186,7 @@ private:
     static uint32 presentIndex;
 
     static VkViewport viewport;
+    static VkRect2D scissors;
 
     static VkSemaphore imageAvailableSemaphore;
     static VkSemaphore renderFinishedSemaphore;


### PR DESCRIPTION
A few small changes to the Vulkan backend to resolve some issues that VK_DEBUG yells at you about when enabled:
- Remove VkDevice layers as those have been deprecated since 1.0: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-devicelayers
- Add actual scissors to viewport as the cast was causing some overflow errors, resulting in very little image being shown at fullscreen on macOS: https://registry.khronos.org/VulkanSC/specs/1.0-extensions/man/html/vkCmdSetScissor.html#VUID-vkCmdSetScissor-offset-00596
- Switch to indexing the semaphores to stop it yelling about reuse issues (already looked good to begin with so this was simple): https://docs.vulkan.org/guide/latest/swapchain_semaphore_reuse.html