### PR TITLE
ModAPI v3: Add support for ModEntity structs

### DIFF
--- a/RSDKv5/RSDK/Core/ModAPI.cpp
+++ b/RSDKv5/RSDK/Core/ModAPI.cpp
@@ -1839,6 +1839,24 @@ void RSDK::ModRegisterObject_STD(Object **staticVars, Object **modStaticVars, co
 #if RETRO_MOD_LOADER_VER >= 3
     if (curMod != nullptr)
         curMod->objectsRegistered.push_back({ info, modEntityClassSize });
+
+    if (create) {
+        create = [curMod, create](void *data) {
+            currentMod = curMod;
+            CreateModEntitiesFor(sceneInfo.entity, &objectClassList[stageObjectIDs[sceneInfo.entity->classID]]);
+            create(data);
+            currentMod = NULL;
+        };
+    }
+
+    if (editorDraw) {
+        editorDraw = [curMod, editorDraw]() {
+            currentMod = curMod;
+            CreateModEntitiesFor(sceneInfo.entity, &objectClassList[stageObjectIDs[sceneInfo.entity->classID]]);
+            editorDraw();
+            currentMod = NULL;
+        };
+    }
 #endif
 
     // clang-format off
@@ -2233,6 +2251,8 @@ void *RSDK::GetModEntityForModID(Entity *entityPtr, const char *modID)
             if (it != registration.entities.end())
                 return it->second;
         }
+
+        return nullptr;
     }
 
     for (auto &mod : modList) {
@@ -2259,6 +2279,8 @@ void *RSDK::GetModEntityForModIndex(Entity *entityPtr, int32 modIndex)
             if (it != registration.entities.end())
                 return it->second;
         }
+
+        return nullptr;
     }
 
     for (size_t i = 0; i < modList.size(); ++i) {

--- a/RSDKv5/RSDK/Core/ModAPI.cpp
+++ b/RSDKv5/RSDK/Core/ModAPI.cpp
@@ -214,6 +214,10 @@ void RSDK::InitModAPI(bool32 getVersion)
     // Mod hooks (Public Functions override)
     ADD_MOD_FUNCTION(ModTable_HookPublicFunction, HookPublicFunction);
 
+    // Entities
+    ADD_MOD_FUNCTION(ModTable_GetModEntityForModID, GetModEntityForModID);
+    ADD_MOD_FUNCTION(ModTable_GetModEntityForModIndex, GetModEntityForModIndex);
+
     // Platform info
     ADD_MOD_FUNCTION(ModTable_GetRetroPlatform, GetRetroPlatform);
 
@@ -1732,32 +1736,51 @@ void RSDK::ModRegisterGlobalVariables(const char *globalsPath, void **globals, u
 
 #if RETRO_REV0U
 void RSDK::ModRegisterObject(Object **staticVars, Object **modStaticVars, const char *name, uint32 entityClassSize, uint32 staticClassSize,
-                             uint32 modClassSize, void (*update)(), void (*lateUpdate)(), void (*staticUpdate)(), void (*draw)(),
+#if RETRO_MOD_LOADER_VER >= 3
+                             uint32 modEntityClassSize,
+#endif
+                             uint32 modStaticClassSize, void (*update)(), void (*lateUpdate)(), void (*staticUpdate)(), void (*draw)(),
                              void (*create)(void *), void (*stageLoad)(), void (*editorLoad)(), void (*editorDraw)(), void (*serialize)(),
                              void (*staticLoad)(Object *), const char *inherited)
 {
-    return ModRegisterObject_STD(staticVars, modStaticVars, name, entityClassSize, staticClassSize, modClassSize, update, lateUpdate, staticUpdate,
-                                 draw, create, stageLoad, editorLoad, editorDraw, serialize, staticLoad, inherited);
+    return ModRegisterObject_STD(staticVars, modStaticVars, name, entityClassSize, staticClassSize,
+#if RETRO_MOD_LOADER_VER >= 3
+                                 modEntityClassSize,
+#endif
+                                 modStaticClassSize, update, lateUpdate, staticUpdate, draw, create, stageLoad, editorLoad, editorDraw, serialize,
+                                 staticLoad, inherited);
 }
 
 void RSDK::ModRegisterObject_STD(Object **staticVars, Object **modStaticVars, const char *name, uint32 entityClassSize, uint32 staticClassSize,
-                                 uint32 modClassSize, std::function<void()> update, std::function<void()> lateUpdate,
+#if RETRO_MOD_LOADER_VER >= 3
+                                 uint32 modEntityClassSize,
+#endif
+                                 uint32 modStaticClassSize, std::function<void()> update, std::function<void()> lateUpdate,
                                  std::function<void()> staticUpdate, std::function<void()> draw, std::function<void(void *)> create,
                                  std::function<void()> stageLoad, std::function<void()> editorLoad, std::function<void()> editorDraw,
                                  std::function<void()> serialize, std::function<void(Object *)> staticLoad, const char *inherited)
 #else
-
 void RSDK::ModRegisterObject(Object **staticVars, Object **modStaticVars, const char *name, uint32 entityClassSize, uint32 staticClassSize,
-                             uint32 modClassSize, void (*update)(), void (*lateUpdate)(), void (*staticUpdate)(), void (*draw)(),
+#if RETRO_MOD_LOADER_VER >= 3
+                             uint32 modEntityClassSize,
+#endif
+                             uint32 modStaticClassSize, void (*update)(), void (*lateUpdate)(), void (*staticUpdate)(), void (*draw)(),
                              void (*create)(void *), void (*stageLoad)(), void (*editorLoad)(), void (*editorDraw)(), void (*serialize)(),
                              const char *inherited)
 {
-    return ModRegisterObject_STD(staticVars, modStaticVars, name, entityClassSize, staticClassSize, modClassSize, update, lateUpdate, staticUpdate,
-                                 draw, create, stageLoad, editorLoad, editorDraw, serialize, inherited);
+    return ModRegisterObject_STD(staticVars, modStaticVars, name, entityClassSize, staticClassSize,
+#if RETRO_MOD_LOADER_VER >= 3
+                                 modEntityClassSize,
+#endif
+                                 modStaticClassSize, update, lateUpdate, staticUpdate, draw, create, stageLoad, editorLoad, editorDraw, serialize,
+                                 inherited);
 }
 
 void RSDK::ModRegisterObject_STD(Object **staticVars, Object **modStaticVars, const char *name, uint32 entityClassSize, uint32 staticClassSize,
-                                 uint32 modClassSize, std::function<void()> update, std::function<void()> lateUpdate,
+#if RETRO_MOD_LOADER_VER >= 3
+                                 uint32 modEntityClassSize,
+#endif
+                                 uint32 modStaticClassSize, std::function<void()> update, std::function<void()> lateUpdate,
                                  std::function<void()> staticUpdate, std::function<void()> draw, std::function<void(void *)> create,
                                  std::function<void()> stageLoad, std::function<void()> editorLoad, std::function<void()> editorDraw,
                                  std::function<void()> serialize, const char *inherited)
@@ -1813,6 +1836,11 @@ void RSDK::ModRegisterObject_STD(Object **staticVars, Object **modStaticVars, co
 
     ObjectClass *info = &objectClassList[objectClassCount - 1];
 
+#if RETRO_MOD_LOADER_VER >= 3
+    if (curMod != nullptr)
+        curMod->objectsRegistered.push_back({ info, modEntityClassSize });
+#endif
+
     // clang-format off
     if (update)       info->update       = [curMod, update]()                       { currentMod = curMod; update();                currentMod = NULL; };
     if (lateUpdate)   info->lateUpdate   = [curMod, lateUpdate]()                   { currentMod = curMod; lateUpdate();            currentMod = NULL; };
@@ -1840,8 +1868,8 @@ void RSDK::ModRegisterObject_STD(Object **staticVars, Object **modStaticVars, co
                 ModRegisterObjectHook(staticVars, name);
             }
             // lets also setup mod static vars
-            if (modStaticVars && modClassSize) {
-                curMod->staticVars[info->hash] = { curMod->id + "_" + name, modStaticVars, modClassSize };
+            if (modStaticVars && modStaticClassSize) {
+                curMod->staticVars[info->hash] = { curMod->id + "_" + name, modStaticVars, modStaticClassSize };
             }
         }
 
@@ -2193,6 +2221,52 @@ void RSDK::UnHookPublicFunctions()
     }
     modPublicFunctionHooks.clear();
 #endif
+}
+
+// Entities
+
+void *RSDK::GetModEntityForModID(Entity *entityPtr, const char *modID)
+{
+    if (modID == nullptr && currentMod != nullptr) {
+        for (auto &registration : currentMod->objectsRegistered) {
+            return registration.entities[entityPtr];
+        }
+    }
+
+    for (auto &mod : modList) {
+        if (!mod.active)
+            continue;
+
+        if (mod.id == std::string(modID)) {
+            for (auto &registration : mod.objectsRegistered) {
+                return registration.entities[entityPtr];
+            }
+        }
+    }
+
+    return nullptr;
+}
+
+void *RSDK::GetModEntityForModIndex(Entity *entityPtr, int32 modIndex)
+{
+    if (modIndex == -1 && currentMod != nullptr) {
+        for (auto &registration : currentMod->objectsRegistered) {
+            return registration.entities[entityPtr];
+        }
+    }
+
+    for (size_t i = 0; i < modList.size(); ++i) {
+        if (!modList[i].active)
+            continue;
+
+        if (i == modIndex) {
+            for (auto &registration : modList[i].objectsRegistered) {
+                return registration.entities[entityPtr];
+            }
+        }
+    }
+
+    return nullptr;
 }
 
 // IO

--- a/RSDKv5/RSDK/Core/ModAPI.cpp
+++ b/RSDKv5/RSDK/Core/ModAPI.cpp
@@ -2229,7 +2229,9 @@ void *RSDK::GetModEntityForModID(Entity *entityPtr, const char *modID)
 {
     if (modID == nullptr && currentMod != nullptr) {
         for (auto &registration : currentMod->objectsRegistered) {
-            return registration.entities[entityPtr];
+            auto it = registration.entities.find(entityPtr);
+            if (it != registration.entities.end())
+                return it->second;
         }
     }
 
@@ -2239,7 +2241,9 @@ void *RSDK::GetModEntityForModID(Entity *entityPtr, const char *modID)
 
         if (mod.id == std::string(modID)) {
             for (auto &registration : mod.objectsRegistered) {
-                return registration.entities[entityPtr];
+                auto it = registration.entities.find(entityPtr);
+                if (it != registration.entities.end())
+                    return it->second;
             }
         }
     }
@@ -2251,7 +2255,9 @@ void *RSDK::GetModEntityForModIndex(Entity *entityPtr, int32 modIndex)
 {
     if (modIndex == -1 && currentMod != nullptr) {
         for (auto &registration : currentMod->objectsRegistered) {
-            return registration.entities[entityPtr];
+            auto it = registration.entities.find(entityPtr);
+            if (it != registration.entities.end())
+                return it->second;
         }
     }
 
@@ -2261,7 +2267,9 @@ void *RSDK::GetModEntityForModIndex(Entity *entityPtr, int32 modIndex)
 
         if (i == modIndex) {
             for (auto &registration : modList[i].objectsRegistered) {
-                return registration.entities[entityPtr];
+                auto it = registration.entities.find(entityPtr);
+                if (it != registration.entities.end())
+                    return it->second;
             }
         }
     }

--- a/RSDKv5/RSDK/Core/ModAPI.hpp
+++ b/RSDKv5/RSDK/Core/ModAPI.hpp
@@ -153,6 +153,10 @@ enum ModFunctionTableIDs {
     // Mod hooks (Public Functions override)
     ModTable_HookPublicFunction,
 
+    // Entities
+    ModTable_GetModEntityForModID,
+    ModTable_GetModEntityForModIndex,
+
     // Platform info
     ModTable_GetRetroPlatform,
 
@@ -218,6 +222,18 @@ struct ModSVInfo {
     uint32 size;
 };
 
+#if RETRO_MOD_LOADER_VER >= 3
+struct ModEntity {
+    int32 index;
+};
+
+struct ModRegisteredObjectInfo {
+    ObjectClass *info;
+    uint32 modEntityClassSize;
+    std::map<Entity *, ModEntity *> entities;
+};
+#endif
+
 struct ModInfo {
     std::string path;
     std::string id;
@@ -235,6 +251,9 @@ struct ModInfo {
     std::map<std::string, std::string> fileMap;
     std::vector<std::string> excludedFiles;
     std::vector<ModPublicFunctionInfo> functionList;
+#if RETRO_MOD_LOADER_VER >= 3
+    std::vector<ModRegisteredObjectInfo> objectsRegistered;
+#endif
     std::vector<Link::Handle> modLogicHandles;
     std::vector<modLinkSTD> linkModLogic;
     void (*unloadMod)();
@@ -330,27 +349,40 @@ void RunModCallbacks(int32 callbackID, void *data);
 void ModRegisterGlobalVariables(const char *globalsPath, void **globals, uint32 size);
 
 void ModRegisterObject(Object **staticVars, Object **modStaticVars, const char *name, uint32 entityClassSize, uint32 staticClassSize,
-                       uint32 modClassSize, void (*update)(), void (*lateUpdate)(), void (*staticUpdate)(), void (*draw)(), void (*create)(void *),
-                       void (*stageLoad)(), void (*editorLoad)(), void (*editorDraw)(), void (*serialize)(), void (*staticLoad)(Object *),
-                       const char *inherited);
+#if RETRO_MOD_LOADER_VER >= 3
+                       uint32 modEntityClassSize,
+#endif
+                       uint32 modStaticClassSize, void (*update)(), void (*lateUpdate)(), void (*staticUpdate)(), void (*draw)(),
+                       void (*create)(void *), void (*stageLoad)(), void (*editorLoad)(), void (*editorDraw)(), void (*serialize)(),
+                       void (*staticLoad)(Object *), const char *inherited);
 
 void ModRegisterObject_STD(Object **staticVars, Object **modStaticVars, const char *name, uint32 entityClassSize, uint32 staticClassSize,
-                           uint32 modClassSize, std::function<void()> update, std::function<void()> lateUpdate, std::function<void()> staticUpdate,
-                           std::function<void()> draw, std::function<void(void *)> create, std::function<void()> stageLoad,
-                           std::function<void()> editorLoad, std::function<void()> editorDraw, std::function<void()> serialize,
-                           std::function<void(Object *)> staticLoad, const char *inherited);
+#if RETRO_MOD_LOADER_VER >= 3
+                           uint32 modEntityClassSize,
+#endif
+                           uint32 modStaticClassSize, std::function<void()> update, std::function<void()> lateUpdate,
+                           std::function<void()> staticUpdate, std::function<void()> draw, std::function<void(void *)> create,
+                           std::function<void()> stageLoad, std::function<void()> editorLoad, std::function<void()> editorDraw,
+                           std::function<void()> serialize, std::function<void(Object *)> staticLoad, const char *inherited);
 #else
 void ModRegisterGlobalVariables(const char *globalsPath, void **globals, uint32 size);
 
 void ModRegisterObject(Object **staticVars, Object **modStaticVars, const char *name, uint32 entityClassSize, uint32 staticClassSize,
-                       uint32 modClassSize, void (*update)(), void (*lateUpdate)(), void (*staticUpdate)(), void (*draw)(), void (*create)(void *),
-                       void (*stageLoad)(), void (*editorLoad)(), void (*editorDraw)(), void (*serialize)(), const char *inherited);
+#if RETRO_MOD_LOADER_VER >= 3
+                       uint32 modEntityClassSize,
+#endif
+                       uint32 modStaticClassSize, void (*update)(), void (*lateUpdate)(), void (*staticUpdate)(), void (*draw)(),
+                       void (*create)(void *), void (*stageLoad)(), void (*editorLoad)(), void (*editorDraw)(), void (*serialize)(),
+                       const char *inherited);
 
 void ModRegisterObject_STD(Object **staticVars, Object **modStaticVars, const char *name, uint32 entityClassSize, uint32 staticClassSize,
-                           uint32 modClassSize, std::function<void()> update, std::function<void()> lateUpdate, std::function<void()> staticUpdate,
-                           std::function<void()> draw, std::function<void(void *)> create, std::function<void()> stageLoad,
-                           std::function<void()> editorLoad, std::function<void()> editorDraw, std::function<void()> serialize,
-                           const char *inherited);
+#if RETRO_MOD_LOADER_VER >= 3
+                           uint32 modEntityClassSize,
+#endif
+                           uint32 modStaticClassSize, std::function<void()> update, std::function<void()> lateUpdate,
+                           std::function<void()> staticUpdate, std::function<void()> draw, std::function<void(void *)> create,
+                           std::function<void()> stageLoad, std::function<void()> editorLoad, std::function<void()> editorDraw,
+                           std::function<void()> serialize, const char *inherited);
 #endif
 
 void ModRegisterObjectHook(Object **staticVars, const char *staticName);
@@ -493,6 +525,10 @@ bool32 GetGroupEntities(uint16 group, void **entity);
 // Mod hooks (Public Functions override)
 void HookPublicFunction(const char *id, const char *functionName, void *functionPtr, void **originalPtr);
 void UnHookPublicFunctions();
+
+// Entities
+void *GetModEntityForModID(Entity *entity, const char *modID);
+void *GetModEntityForModIndex(Entity *entity, int32 modIndex);
 
 // Platform info
 inline int32 GetRetroPlatform(void) { return RETRO_PLATFORM; }

--- a/RSDKv5/RSDK/Core/RetroEngine.cpp
+++ b/RSDKv5/RSDK/Core/RetroEngine.cpp
@@ -1241,6 +1241,13 @@ void RSDK::LoadGameConfig()
 void RSDK::InitGameLink()
 {
 #if RETRO_USE_MOD_LOADER
+#if RETRO_MOD_LOADER_VER >= 3
+    for (int32 e = 0; e < ENTITY_COUNT; ++e) {
+        if (objectEntityList[e].classID)
+            DestroyModEntitiesFor(&objectEntityList[e]);
+    }
+#endif
+
     objectClassCount = 0;
     memset(globalObjectIDs, 0, sizeof(globalObjectIDs));
     memset(objectEntityList, 0, sizeof(objectEntityList));

--- a/RSDKv5/RSDK/Core/RetroEngine.cpp
+++ b/RSDKv5/RSDK/Core/RetroEngine.cpp
@@ -1242,10 +1242,7 @@ void RSDK::InitGameLink()
 {
 #if RETRO_USE_MOD_LOADER
 #if RETRO_MOD_LOADER_VER >= 3
-    for (int32 e = 0; e < ENTITY_COUNT; ++e) {
-        if (objectEntityList[e].classID)
-            DestroyModEntitiesFor(&objectEntityList[e]);
-    }
+    DestroyModEntitiesAll();
 #endif
 
     objectClassCount = 0;

--- a/RSDKv5/RSDK/Scene/Object.cpp
+++ b/RSDKv5/RSDK/Scene/Object.cpp
@@ -1077,11 +1077,12 @@ void RSDK::DestroyModEntitiesFor(Entity *entity)
             continue;
 
         for (auto &registration : mod.objectsRegistered) {
-            if (!registration.entities[entity])
+            auto it = registration.entities.find(entity);
+            if (!it->second || it == registration.entities.end())
                 continue;
 
-            delete[] registration.entities[entity];
-            registration.entities[entity] = nullptr;
+            delete[] it->second;
+            registration.entities.erase(it);
         }
     }
 }

--- a/RSDKv5/RSDK/Scene/Object.cpp
+++ b/RSDKv5/RSDK/Scene/Object.cpp
@@ -314,6 +314,13 @@ void RSDK::InitObjects()
 
 #if RETRO_USE_MOD_LOADER && RETRO_MOD_LOADER_VER >= 3
     RunModCallbacks(MODCB_BEFORESTAGELOAD, NULL);
+
+    // Create mod entities *before* any events are called
+    for (int32 e = 0; e < ENTITY_COUNT; ++e) {
+        Entity *entity = &objectEntityList[e];
+        if (entity->classID)
+            CreateModEntitiesFor(entity, &objectClassList[stageObjectIDs[entity->classID]]);
+    }
 #endif
 
     for (int32 o = 0; o < sceneInfo.classCount; ++o) {
@@ -854,7 +861,7 @@ void RSDK::ProcessObjectDrawLists()
                                     case ACTIVE_NEVER: break;
 
                                     case ACTIVE_ALWAYS:
-                                    case ACTIVE_NORMAL: 
+                                    case ACTIVE_NORMAL:
                                     case ACTIVE_PAUSED:
                                         DrawRectangle(entity->position.x, entity->position.y, TO_FIXED(1), TO_FIXED(1), 0x0000FF, 0xFF, INK_NONE,
                                                       false);
@@ -1032,6 +1039,54 @@ uint16 RSDK::FindObject(const char *name)
     return TYPE_DEFAULTOBJECT;
 }
 
+#if RETRO_USE_MOD_LOADER && RETRO_MOD_LOADER_VER >= 3
+void RSDK::CreateModEntitiesFor(Entity *entity, ObjectClass *objClass)
+{
+    if (!objClass->staticVars || !*objClass->staticVars)
+        return;
+
+    for (size_t i = 0; i < modList.size(); ++i) {
+        if (!modList[i].active)
+            continue;
+
+        for (auto &registration : modList[i].objectsRegistered) {
+            // no struct or it isn't inheriting from ModEntity so we shouldn't allocate anything
+            if (registration.modEntityClassSize < sizeof(ModEntity))
+                continue;
+
+            ObjectClass *modObjClass = registration.info;
+            if (!modObjClass->staticVars || !*modObjClass->staticVars)
+                continue;
+
+            if ((*modObjClass->staticVars)->classID != (*objClass->staticVars)->classID)
+                continue;
+
+            ModEntity *modEntity = (ModEntity *)(new byte[registration.modEntityClassSize]);
+            memset(modEntity, 0, registration.modEntityClassSize);
+            modEntity->index = i;
+
+            registration.entities[entity] = modEntity;
+        }
+    }
+}
+
+void RSDK::DestroyModEntitiesFor(Entity *entity)
+{
+    for (auto &mod : modList) {
+        if (!mod.active)
+            continue;
+
+        for (auto &registration : mod.objectsRegistered) {
+            if (!registration.entities[entity])
+                continue;
+
+            delete[] registration.entities[entity];
+            registration.entities[entity] = nullptr;
+        }
+    }
+}
+#endif
+
 int32 RSDK::GetEntityCount(uint16 classID, bool32 isActive)
 {
     if (classID >= TYPE_COUNT)
@@ -1052,6 +1107,11 @@ void RSDK::ResetEntity(Entity *entity, uint16 classID, void *data)
 {
     if (entity) {
         ObjectClass *info = &objectClassList[stageObjectIDs[classID]];
+
+#if RETRO_USE_MOD_LOADER && RETRO_MOD_LOADER_VER >= 3
+        DestroyModEntitiesFor(entity);
+#endif
+
         memset(entity, 0, info->entityClassSize);
 
         if (info->create) {
@@ -1062,6 +1122,9 @@ void RSDK::ResetEntity(Entity *entity, uint16 classID, void *data)
 #if RETRO_USE_MOD_LOADER
             int32 superStore          = superLevels[inheritLevel];
             superLevels[inheritLevel] = 0;
+#if RETRO_MOD_LOADER_VER >= 3
+            CreateModEntitiesFor(sceneInfo.entity, info);
+#endif
 #endif
             info->create(data);
 #if RETRO_USE_MOD_LOADER
@@ -1082,6 +1145,11 @@ void RSDK::ResetEntitySlot(uint16 slot, uint16 classID, void *data)
     slot                = slot < ENTITY_COUNT ? slot : (ENTITY_COUNT - 1);
 
     Entity *entity = &objectEntityList[slot];
+
+#if RETRO_USE_MOD_LOADER && RETRO_MOD_LOADER_VER >= 3
+    DestroyModEntitiesFor(entity);
+#endif
+
     memset(&objectEntityList[slot], 0, object->entityClassSize);
 
     if (object->create) {
@@ -1092,6 +1160,9 @@ void RSDK::ResetEntitySlot(uint16 slot, uint16 classID, void *data)
 #if RETRO_USE_MOD_LOADER
         int32 superStore          = superLevels[inheritLevel];
         superLevels[inheritLevel] = 0;
+#if RETRO_MOD_LOADER_VER >= 3
+        CreateModEntitiesFor(sceneInfo.entity, object);
+#endif
 #endif
         object->create(data);
 #if RETRO_USE_MOD_LOADER
@@ -1135,10 +1206,18 @@ Entity *RSDK::CreateEntity(uint16 classID, void *data, int32 x, int32 y)
         ++loopCnt;
     }
 
+#if RETRO_USE_MOD_LOADER && RETRO_MOD_LOADER_VER >= 3
+    DestroyModEntitiesFor(entity);
+#endif
+
     memset(entity, 0, object->entityClassSize);
     entity->position.x  = x;
     entity->position.y  = y;
     entity->interaction = true;
+
+#if RETRO_USE_MOD_LOADER && RETRO_MOD_LOADER_VER >= 3
+    CreateModEntitiesFor(entity, object);
+#endif
 
     if (object->create) {
         Entity *curEnt = sceneInfo.entity;

--- a/RSDKv5/RSDK/Scene/Object.cpp
+++ b/RSDKv5/RSDK/Scene/Object.cpp
@@ -314,13 +314,6 @@ void RSDK::InitObjects()
 
 #if RETRO_USE_MOD_LOADER && RETRO_MOD_LOADER_VER >= 3
     RunModCallbacks(MODCB_BEFORESTAGELOAD, NULL);
-
-    // Create mod entities *before* any events are called
-    for (int32 e = 0; e < ENTITY_COUNT; ++e) {
-        Entity *entity = &objectEntityList[e];
-        if (entity->classID)
-            CreateModEntitiesFor(entity, &objectClassList[stageObjectIDs[entity->classID]]);
-    }
 #endif
 
     for (int32 o = 0; o < sceneInfo.classCount; ++o) {
@@ -1061,11 +1054,17 @@ void RSDK::CreateModEntitiesFor(Entity *entity, ObjectClass *objClass)
             if ((*modObjClass->staticVars)->classID != (*objClass->staticVars)->classID)
                 continue;
 
-            ModEntity *modEntity = (ModEntity *)(new byte[registration.modEntityClassSize]);
-            memset(modEntity, 0, registration.modEntityClassSize);
-            modEntity->index = i;
+            // We're hijacking the entity's create event to allocate its ModEntities.
+            // We don't want to delete existing ModEntities in this function because RSDKv5 projects will usually use entity->Create() to reset its
+            // properties. However, this is *still* a valid entity instance until we intentionally destroy it.
+            auto it = registration.entities.find(entity);
+            if (it == registration.entities.end()) {
+                ModEntity *modEntity = (ModEntity *)(new byte[registration.modEntityClassSize]);
+                memset(modEntity, 0, registration.modEntityClassSize);
+                modEntity->index = i;
 
-            registration.entities[entity] = modEntity;
+                registration.entities[entity] = modEntity;
+            }
         }
     }
 }
@@ -1078,11 +1077,28 @@ void RSDK::DestroyModEntitiesFor(Entity *entity)
 
         for (auto &registration : mod.objectsRegistered) {
             auto it = registration.entities.find(entity);
-            if (!it->second || it == registration.entities.end())
+            if (it == registration.entities.end() || !it->second)
                 continue;
 
             delete[] it->second;
             registration.entities.erase(it);
+        }
+    }
+}
+
+void RSDK::DestroyModEntitiesAll()
+{
+    for (auto &mod : modList) {
+        if (!mod.active)
+            continue;
+
+        for (auto &registration : mod.objectsRegistered) {
+            for (auto &entity : registration.entities) {
+                if (entity.second != nullptr)
+                    delete[] entity.second;
+            }
+
+            registration.entities.clear();
         }
     }
 }
@@ -1115,6 +1131,11 @@ void RSDK::ResetEntity(Entity *entity, uint16 classID, void *data)
 
         memset(entity, 0, info->entityClassSize);
 
+#if RETRO_USE_MOD_LOADER && RETRO_MOD_LOADER_VER >= 3
+        // object->create() would handle this for us, but we also need this to work without the event
+        CreateModEntitiesFor(entity, info);
+#endif
+
         if (info->create) {
             Entity *curEnt = sceneInfo.entity;
 
@@ -1123,9 +1144,6 @@ void RSDK::ResetEntity(Entity *entity, uint16 classID, void *data)
 #if RETRO_USE_MOD_LOADER
             int32 superStore          = superLevels[inheritLevel];
             superLevels[inheritLevel] = 0;
-#if RETRO_MOD_LOADER_VER >= 3
-            CreateModEntitiesFor(sceneInfo.entity, info);
-#endif
 #endif
             info->create(data);
 #if RETRO_USE_MOD_LOADER
@@ -1153,6 +1171,11 @@ void RSDK::ResetEntitySlot(uint16 slot, uint16 classID, void *data)
 
     memset(&objectEntityList[slot], 0, object->entityClassSize);
 
+#if RETRO_USE_MOD_LOADER && RETRO_MOD_LOADER_VER >= 3
+    // object->create() would handle this for us, but we also need this to work without the event
+    CreateModEntitiesFor(entity, object);
+#endif
+
     if (object->create) {
         Entity *curEnt = sceneInfo.entity;
 
@@ -1161,9 +1184,6 @@ void RSDK::ResetEntitySlot(uint16 slot, uint16 classID, void *data)
 #if RETRO_USE_MOD_LOADER
         int32 superStore          = superLevels[inheritLevel];
         superLevels[inheritLevel] = 0;
-#if RETRO_MOD_LOADER_VER >= 3
-        CreateModEntitiesFor(sceneInfo.entity, object);
-#endif
 #endif
         object->create(data);
 #if RETRO_USE_MOD_LOADER
@@ -1217,6 +1237,7 @@ Entity *RSDK::CreateEntity(uint16 classID, void *data, int32 x, int32 y)
     entity->interaction = true;
 
 #if RETRO_USE_MOD_LOADER && RETRO_MOD_LOADER_VER >= 3
+    // object->create() would handle this for us, but we also need this to work without the event
     CreateModEntitiesFor(entity, object);
 #endif
 

--- a/RSDKv5/RSDK/Scene/Object.hpp
+++ b/RSDKv5/RSDK/Scene/Object.hpp
@@ -293,6 +293,7 @@ uint16 FindObject(const char *name);
 #if RETRO_USE_MOD_LOADER && RETRO_MOD_LOADER_VER >= 3
 void CreateModEntitiesFor(Entity *entity, ObjectClass *objClass);
 void DestroyModEntitiesFor(Entity *entity);
+void DestroyModEntitiesAll();
 #endif
 
 inline Entity *GetEntity(uint16 slot) { return &objectEntityList[slot < ENTITY_COUNT ? slot : (ENTITY_COUNT - 1)]; }

--- a/RSDKv5/RSDK/Scene/Object.hpp
+++ b/RSDKv5/RSDK/Scene/Object.hpp
@@ -290,6 +290,11 @@ void ProcessObjectDrawLists();
 
 uint16 FindObject(const char *name);
 
+#if RETRO_USE_MOD_LOADER && RETRO_MOD_LOADER_VER >= 3
+void CreateModEntitiesFor(Entity *entity, ObjectClass *objClass);
+void DestroyModEntitiesFor(Entity *entity);
+#endif
+
 inline Entity *GetEntity(uint16 slot) { return &objectEntityList[slot < ENTITY_COUNT ? slot : (ENTITY_COUNT - 1)]; }
 inline int32 GetEntitySlot(EntityBase *entity) { return (int32)((uint32)(entity - objectEntityList) < ENTITY_COUNT ? entity - objectEntityList : 0); }
 int32 GetEntityCount(uint16 classID, bool32 isActive);

--- a/RSDKv5/RSDK/Scene/Scene.cpp
+++ b/RSDKv5/RSDK/Scene/Scene.cpp
@@ -295,10 +295,7 @@ void RSDK::LoadSceneAssets()
 #endif
 
 #if RETRO_USE_MOD_LOADER && RETRO_MOD_LOADER_VER >= 3
-    for (int32 e = 0; e < ENTITY_COUNT; ++e) {
-        if (objectEntityList[e].classID)
-            DestroyModEntitiesFor(&objectEntityList[e]);
-    }
+    DestroyModEntitiesAll();
 #endif
 
     memset(objectEntityList, 0, ENTITY_COUNT * sizeof(EntityBase));

--- a/RSDKv5/RSDK/Scene/Scene.cpp
+++ b/RSDKv5/RSDK/Scene/Scene.cpp
@@ -294,6 +294,13 @@ void RSDK::LoadSceneAssets()
     ShowLoadingIcon();
 #endif
 
+#if RETRO_USE_MOD_LOADER && RETRO_MOD_LOADER_VER >= 3
+    for (int32 e = 0; e < ENTITY_COUNT; ++e) {
+        if (objectEntityList[e].classID)
+            DestroyModEntitiesFor(&objectEntityList[e]);
+    }
+#endif
+
     memset(objectEntityList, 0, ENTITY_COUNT * sizeof(EntityBase));
 
     SceneListEntry *sceneEntry = &sceneInfo.listData[sceneInfo.listPos];
@@ -1123,7 +1130,7 @@ void RSDK::ProcessParallax(TileLayer *layer)
 
             uint16 scrollPos =
                 FROM_FIXED((int32)((layer->scrollPos + (layer->parallaxFactor * currentScreen->position.x << 8)) & 0xFFFF0000)) % pixelWidth;
- 
+
             uint8 *lineScrollPtr = &layer->lineScroll[scrollPos];
 
             // Above water


### PR DESCRIPTION
```cpp
- auto *entity = GameObject::Create<Type>(slot):
-- -- Mod1::ModEntity[Mod1::modEntitySize];
-- -- Mod2::ModEntity[Mod2::modEntitySize];
```
```cpp
struct Mod1::ModEntity {
    int32 variable;
};

void Type::Update() {
    // for currently running mod
    mod->variable = 1;
}
```
```cpp
struct Mod2::ModEntity {
    uint8 variable;
};

void Type::Update() {
    // for currently running mod
    mod->variable = 2;
    
    // if Mod2 knows the struct for Mod1, we can modify its variables for auto *entity
    struct Mod1Entity : Mod::Entity {
        int32 variable;
    };
    
    Mod1Entity *mod1 = (Mod1Entity *)Mod::Entity::Get<Type>(entity, "Mod1");
    mod1->variable++;
}
```